### PR TITLE
Feat: Introduce generic BatchSinker

### DIFF
--- a/datastreams/sinks/batch_sinker.go
+++ b/datastreams/sinks/batch_sinker.go
@@ -1,0 +1,47 @@
+package sinks
+
+import (
+	"context"
+	"github.com/elastiflow/pipelines/datastreams"
+)
+
+type BatchSinker[T any] struct {
+	onFlush func(context.Context, []T) error
+	batch   []T
+	errs    chan error
+}
+
+func NewSinker[T any](onFlush func(context.Context, []T) error, batchSize int, errs chan error) *BatchSinker[T] {
+	return &BatchSinker[T]{
+		onFlush: onFlush,
+		batch:   make([]T, 0, batchSize),
+	}
+}
+
+func (s *BatchSinker[T]) Sink(ctx context.Context, ds datastreams.DataStream[T]) error {
+	for {
+		select {
+		case <-ctx.Done():
+			// Flush any remaining items in the batch
+			s.flush(ctx, s.Next())
+			return nil
+		case val := <-ds.Out():
+			s.batch = append(s.batch, val)
+			if len(s.batch) == cap(s.batch) {
+				go s.flush(ctx, s.Next())
+			}
+		}
+	}
+}
+
+func (s *BatchSinker[T]) flush(ctx context.Context, elems []T) {
+	if err := s.onFlush(ctx, elems); err != nil {
+		s.errs <- err
+	}
+}
+
+func (s *BatchSinker[T]) Next() []T {
+	next := s.batch
+	s.batch = s.batch[:0]
+	return next
+}

--- a/datastreams/sinks/batch_sinker_test.go
+++ b/datastreams/sinks/batch_sinker_test.go
@@ -1,0 +1,92 @@
+package sinks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastiflow/pipelines/datastreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockFlusher is a thread-safe helper for testing onFlush calls.
+type mockFlusher[T any] struct {
+	mock.Mock
+}
+
+func (m *mockFlusher[T]) onFlush(ctx context.Context, batch []T) error {
+	args := m.Called(batch)
+	return args.Error(0)
+}
+
+func TestNewSinker(t *testing.T) {
+	mockFlushFunc := func(context.Context, []int) error { return nil }
+	errs := make(chan error, 1)
+	batchSize := 10
+
+	sinker := NewSinker(mockFlushFunc, batchSize, errs)
+
+	require.NotNil(t, sinker)
+	assert.NotNil(t, sinker.onFlush)
+	assert.NotNil(t, sinker.batch)
+	assert.Equal(t, 0, len(sinker.batch), "Batch slice should be initialized with a length of 0")
+	assert.Equal(t, batchSize, cap(sinker.batch), "Batch slice should have capacity equal to batchSize")
+}
+
+func TestBatchSinker_Sink(t *testing.T) {
+	testcases := []struct {
+		name        string
+		batchSize   int
+		input       []int
+		expected    [][]int
+		assertFlush func(t *testing.T, flusher *mockFlusher[int])
+	}{
+		{
+			name:      "call the onFlush function with a full batch",
+			batchSize: 3,
+			input:     []int{1, 2, 3},
+			expected:  [][]int{{1, 2, 3}},
+			assertFlush: func(t *testing.T, flusher *mockFlusher[int]) {
+				flusher.AssertCalled(t, "onFlush", []int{1, 2, 3})
+			},
+		},
+		{
+			name:      "if full batch is not reached before timeout, flush the remaining items",
+			batchSize: 5,
+			input:     []int{1, 2, 3},
+			expected:  [][]int{{1, 2, 3}},
+			assertFlush: func(t *testing.T, flusher *mockFlusher[int]) {
+				flusher.AssertCalled(t, "onFlush", []int{1, 2, 3})
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			flusher := &mockFlusher[int]{}
+			errChan := make(chan error, 1)
+			flusher.On("onFlush", mock.Anything).Return(nil)
+			sinker := NewSinker(flusher.onFlush, tc.batchSize, errChan)
+			sinker.batch = make([]int, 0, tc.batchSize)
+
+			inChan := make(chan int, len(tc.input))
+			sourceDS := datastreams.New[int](ctx, inChan, errChan)
+			go func() {
+				for _, val := range tc.input {
+					inChan <- val
+				}
+			}()
+
+			// Send data
+			_ = sinker.Sink(ctx, sourceDS)
+
+			// Assertions
+			tc.assertFlush(t, flusher)
+		})
+	}
+}


### PR DESCRIPTION
# Description
This PR introduces BatchSinker, a new, generic sink that collects items from a data stream into batches before flushing them.

Many destinations, such as a Postgres database or an API endpoint, operate much more efficiently when data is sent in bulk rather than as individual items. This sink provides a reusable mechanism to handle this common pattern.

The BatchSinker is configured with a batchSize and a custom onFlush function, allowing it to be adapted to any destination that benefits from batching.

Changes summary
[FEAT] Added BatchSinker, a new generic sink for batching data before processing.


# QA/testing plan

(Provide information on how to test your changes.)

- [ ] Skip QA (if checked, provide a reason below).
- [ ] No code change (if checked, provide a reason below).
- [x] Automated integration testing.

# Reviewer's Checklist

- [ ] Ran linter (_make lint_).
- [ ] Ran security scan (_make scan\:sca_).
- [ ] All automated tests passed.
- [ ] Updated godoc (_make docs_).
- [ ] Updated examples.
