### PR TITLE
Feat: Add Pipelines Type + Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ transformations or filtering in a concurrent manner.
 
 ## High-Level Details
 
+### Pipelines
+
+The `Pipelines` type represents a collection of `Pipeline` instances. It is designed to simplify managing multiple concurrent pipelines, especially when you split a single data source into several parallel streams (i.e., using `Broadcast`). This allows you to control a group of pipelines as a single unit, for example, starting or stopping them all at once.
+
 ### Pipeline
 
-A pipeline is a series of data processing stages connected by channels. Each stage (`datastreams.DataStream`) is a function that performs a specific task and passes its output to the next stage. The `pipelines` module provides a flexible way to define and manage these stages.
+A `Pipeline` is a series of data processing stages connected by channels. Each stage (`datastreams.DataStream`) is a function that performs a specific task and passes its output to the next stage. The `pipelines` module provides a flexible way to define and manage these stages.
 
 ### DataStream
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -20,6 +20,7 @@ package pipelines
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/elastiflow/pipelines/datastreams"
@@ -41,7 +42,7 @@ type Opts struct {
 
 // Pipeline is a struct that defines a generic stream process.
 //
-// Pipeline[T, U] represents a flow of data of type T at the input,
+// Pipeline[T, U] represents a flow of data type T at the input,
 // ultimately producing data of type U at the output. Under the hood,
 // a Pipeline orchestrates DataStream stages connected by channels.
 //
@@ -87,7 +88,7 @@ func (p *Pipeline[T, U]) Close() {
 	p.cancelFunc()
 }
 
-// Errors returns the error channel of the Pipeline.
+// Errors method returns the error channel of the Pipeline.
 //
 // This channel receives errors from any stage (e.g. transformations, filters, sinks).
 // The caller should consume from it to handle errors appropriately.
@@ -130,6 +131,9 @@ func (p *Pipeline[T, U]) Expand(
 // Example:
 //
 //	pipeline.Stream(func(ds DataStream[int]) DataStream[int] { ... })
+//
+// Parameters:
+//   - streamFunc: A function that takes a data stream and returns a new one.
 func (p *Pipeline[T, U]) Stream(streamFunc StreamFunc[T, U]) datastreams.DataStream[U] {
 	p.sinkDS = streamFunc(p.sourceDS.WithWaitGroup(p.wg))
 	return p.sinkDS
@@ -142,17 +146,22 @@ func (p *Pipeline[T, U]) Stream(streamFunc StreamFunc[T, U]) datastreams.DataStr
 // Example:
 //
 //	pipeline.Start(func(ds DataStream[int]) DataStream[int] { ... }).Start(...)
+//
+// Parameters:
+//   - streamFunc: A function that takes a data stream and returns a new one.
 func (p *Pipeline[T, U]) Start(streamFunc StreamFunc[T, U]) *Pipeline[T, U] {
 	p.sinkDS = streamFunc(p.sourceDS.WithWaitGroup(p.wg))
 	return p
 }
 
 // Sink consumes the pipeline's sink DataStream using a specified datastreams.Sinker.
-//
-//   - sinker: a Sinker that will receive data of type U
-//   - returns an error if the sink fails; otherwise nil.
-//
 // Typically used to push output to a custom location or channel.
+//
+// Parameters:
+//   - sinker: A Sinker that will receive data of type U.
+//
+// Returns:
+//   - An error if the sink fails; otherwise nil.
 func (p *Pipeline[T, U]) Sink(sinker datastreams.Sinker[U]) error {
 	return sinker.Sink(p.ctx, p.sinkDS)
 }
@@ -173,12 +182,55 @@ func (p *Pipeline[T, U]) Out() <-chan U {
 	return p.sinkDS.Out()
 }
 
-// Process creates a new pipeline by applying a ProcessFunc to each message
-// in the current pipeline's source. It internally starts a new pipeline with
-// the processed DataStream. This is a convenience for quickly chaining transformations.
+// Process adds a new processing stage to the pipeline, applying a function
+// to each item. The processing function must take and return an item of the
+// same type, making this method ideal for in-place transformations like
+// data enrichment or filtering.
 //
-//   - processor: a ProcessFunc[T] that may transform T in place
-//   - params: optional datastreams.Params
+// This method returns a new Pipeline instance that incorporates the new
+// processing stage, allowing multiple Process calls to be fluently chained
+// together. The final output type of the pipeline (U) remains unchanged.
+//
+// The provided 'processor' function is of type datastreams.ProcessFunc[T],
+// with the signature 'func(T) (T, error)'. If the function returns a non-nil
+// error, processing for that item halts, and the error is sent to the
+// pipeline's error channel.
+//
+// Example:
+//
+//	// Assume a pipeline processes User objects.
+//	type User struct {
+//		ID        int
+//		Name      string
+//		IsValid   bool
+//		IsAudited bool
+//	}
+//
+//	// p is an existing pipeline, e.g., p := pipelines.New[User, User](...)
+//
+//	// We can chain multiple Process calls to create a multi-stage workflow.
+//	finalPipeline := p.Process(func(u User) (User, error) {
+//		// Stage 1: Validate the user.
+//		if u.Name != "" {
+//			u.IsValid = true
+//		}
+//		return u, nil
+//	}).Process(func(u User) (User, error) {
+//		// Stage 2: Audit the user.
+//		if u.IsValid {
+//			u.IsAudited = true
+//			fmt.Printf("Audited user %d\n", u.ID)
+//		}
+//		return u, nil
+//	})
+//
+//	// The finalPipeline now contains both processing stages.
+//	// You can then consume the results from finalPipeline.Out().
+//
+// Parameters:
+//   - processor: a datastreams.ProcessFunc[T] to apply to each item.
+//   - params: optional datastreams.Params to configure the processing stage,
+//     i.e., for setting concurrency.
 func (p *Pipeline[T, U]) Process(
 	processor datastreams.ProcessFunc[T],
 	params ...datastreams.Params,
@@ -213,7 +265,7 @@ func (p *Pipeline[T, U]) ToSource() datastreams.Sourcer[U] {
 
 // Broadcast creates multiple copies of the pipeline's source DataStream,
 // allowing the same data to be processed in parallel by multiple downstream stages.
-func (p *Pipeline[T, U]) Broadcast(num int) []*Pipeline[T, U] {
+func (p *Pipeline[T, U]) Broadcast(num int) Pipelines[T, U] {
 	next := p.sourceDS.Broadcast(datastreams.Params{
 		Num: num,
 	})
@@ -237,4 +289,129 @@ func (p *Pipeline[T, U]) Broadcast(num int) []*Pipeline[T, U] {
 func (p *Pipeline[T, U]) Wait() {
 	p.wg.Wait() // Blocks until all goroutines managed by p.wg have returned
 	close(p.errorChan)
+}
+
+// Pipelines represents a collection of Pipeline instances, designed to simplify
+// the management of concurrent, parallel data processing workflows. It is
+// typically created when a single data source is split into multiple streams
+// using methods like Broadcast.
+//
+// By grouping related pipelines, this type allows for collective operations
+// such as starting, stopping, or waiting for all of them with a single method call.
+// This is particularly useful for scaling up processing by distributing work
+// across multiple concurrent workers that share the same processing logic.
+//
+// Example usage:
+//
+//	pipeline := mainPipeline.Broadcast(3)
+//	pipelines.Start(myProcessingFunc)
+//	pipelines.Wait()
+type Pipelines[T any, U any] []*Pipeline[T, U]
+
+// Count returns the number of pipelines in the collection.
+func (p Pipelines[T, U]) Count() int {
+	return len(p)
+}
+
+// Get returns the pipeline at the specified index. It returns an error if the
+// index is out of bounds.
+func (p Pipelines[T, U]) Get(index int) (*Pipeline[T, U], error) {
+	if index < 0 || index >= p.Count() {
+		return nil, fmt.Errorf("pipelines: index out of range [%d] with pipelines length %d", index, p.Count())
+	}
+	return p[index], nil
+}
+
+// Start applies a StreamFunc to each pipeline in the collection, initiating
+// the data processing flow. It is typically used after a Broadcast to run the
+// same logic in parallel across multiple pipelines.
+//
+// The method returns the collection itself to allow for method chaining.
+//
+// Example:
+//
+//	// p is a single pipeline from which we broadcast
+//	workers := p.Broadcast(3) // Create 3 worker pipelines
+//
+//	// Define the processing logic for each worker
+//	processingFunc := func(stream datastreams.DataStream[int]) datastreams.DataStream[int] {
+//		// For example, map values to multiply by 2
+//		return datastreams.Map(stream, func(i int) int {
+//			return i * 2
+//		})
+//	}
+//
+//	// Start all workers with the defined logic
+//	workers.Start(processingFunc)
+//
+//	// Now, results can be gathered from each pipeline in the 'workers' collection.
+func (p Pipelines[T, U]) Start(streamFunc StreamFunc[T, U]) Pipelines[T, U] {
+	for _, pipeline := range p {
+		if pipeline != nil {
+			pipeline.Start(streamFunc)
+		}
+	}
+	return p
+}
+
+// Process applies a processing function to each pipeline in the collection,
+// adding a new processing stage to each one. This is a convenient way to apply
+// the same transformation logic to multiple parallel streams, such as those
+// created by Broadcast.
+//
+// Each pipeline in the collection is replaced by a new pipeline that includes
+// the additional processing step. The method returns the modified collection
+// to allow for method chaining.
+//
+// Example:
+//
+//	// p is a single pipeline from which we broadcast.
+//	workers := p.Broadcast(2) // Create 2 worker pipelines.
+//
+//	// Define a processor that doubles an integer.
+//	double := func(i int) (int, error) {
+//		return i * 2, nil
+//	}
+//
+//	// Apply the processor to all worker pipelines.
+//	workers.Process(double)
+//
+//	// The pipelines in the 'workers' collection now each have an additional
+//	// stage that doubles the numbers passing through them.
+//
+// Parameters:
+//   - processor: a datastreams.ProcessFunc[T] to apply to each item.
+//   - params: optional datastreams.Params to configure the processing stage,
+//     i.e., for setting concurrency.
+func (p Pipelines[T, U]) Process(
+	processor datastreams.ProcessFunc[T],
+	params ...datastreams.Params,
+) Pipelines[T, U] {
+	for i, pipeline := range p {
+		if pipeline != nil {
+			p[i] = pipeline.Process(processor, params...)
+		}
+	}
+	return p
+}
+
+// Wait blocks until all pipelines in the collection have finished processing.
+// This is useful for ensuring that all data has been consumed before the
+// application exits.
+func (p Pipelines[T, U]) Wait() {
+	for _, pipeline := range p {
+		if pipeline != nil {
+			pipeline.wg.Wait()
+		}
+	}
+}
+
+// Close gracefully shuts down all pipelines in the collection by canceling their
+// underlying contexts.
+func (p Pipelines[T, U]) Close() {
+	for _, pipeline := range p {
+		if pipeline != nil {
+			pipeline.Close()
+		}
+	}
 }


### PR DESCRIPTION
# Description

This pull request introduces the foundational, generic `Pipelines` collection type has been added to manage groups of individual `Pipeline` instances, which is particularly useful for controlling parallel streams in fan-out/fan-in scenarios.

# Changes summary

- **[FEAT]** Introduce `Pipelines[T, U]`
- **[FEAT]** Implement core `Pipelines` methods to build and manage the data stream:
    - `Close()`
    - `Process()`
    - `Start()`
    - `Wait()`
- **[DOCS]** Update `README.md` with documentation for the new `Pipelines` type.

# Issues

- Closes #25
- Related to #24

# QA/testing plan

- [ ] Skip QA (if checked, provide a reason below).
- [ ] No code change (if checked, provide a reason below).
- [x] Automated integration testing.

# Reviewer's Checklist

- [x] Ran linter (_make lint_).
- [x] Ran security scan (_make scan\:sca_).
- [x] All automated tests passed.
- [x] Updated godoc (_make docs_).
- [x] Updated examples.
